### PR TITLE
Updated full spectrum light detection to use the fixed string 'type' …

### DIFF
--- a/resources/lib/tools.py
+++ b/resources/lib/tools.py
@@ -114,8 +114,8 @@ class Light:
     self.onLast = state['on']
     self.valLast = state['bri']
     
-    modelid = j['modelid']
-    self.fullSpectrum = ((modelid == 'LST001') or (modelid == 'LLC007'))
+    lighttype = j['type']
+    self.fullSpectrum = ((lighttype == 'Color Light') or (lighttype == 'Extended Color Light'))
 
     if state.has_key('hue'):
       self.start_setting['hue'] = state['hue']
@@ -392,9 +392,6 @@ class Group(Light):
 
     self.onLast = self.start_setting['on']
     self.valLast = self.start_setting['bri']
-    
-    # modelid = j['modelid']
-    # self.fullSpectrum = ((modelid == 'LST001') or (modelid == 'LLC007'))
 
     if state.has_key('hue'):
       self.start_setting['hue'] = state['hue']


### PR DESCRIPTION
…rather than 'modelid' in order to support the full range now and in future of Hue colour lights.

Both the old 'Color Light' and the newer 'Extended Color Light' are detected as full spectrum.

Technically the Extended Color Light have a different color range than the Color Light but it still works OK with them (I have multiple GU10 LCT003 bulbs)

Reference to Hue Light Models: http://www.developers.meethue.com/documentation/supported-lights
