### PR TITLE
playlists fixes

### DIFF
--- a/default.py
+++ b/default.py
@@ -86,7 +86,7 @@ class MyPlayer(xbmc.Player):
 
   def onPlayBackStarted(self):
     xbmc.log("Kodi Hue: DEBUG playback started called on player")
-    if self.isPlayingVideo():
+    if self.isPlayingVideo() and not self.playingvideo:
       self.playingvideo = True
       self.duration = self.getTotalTime()
       self.movie = xbmc.getCondVisibility('VideoPlayer.Content(movies)')
@@ -128,14 +128,6 @@ class MyPlayer(xbmc.Player):
     if self.movie and not self.timer is None:
       self.timer.stop()
     state_changed("stopped", self.duration)
-
-  def onPlayBackEnded(self):
-    xbmc.log("Kodi Hue: DEBUG playback ended called on player")
-    if self.playingvideo:
-      self.playingvideo = False
-      if self.movie and not self.timer is None:
-        self.timer.stop()
-      state_changed("stopped", self.duration)
 
 class Hue:
   params = None

--- a/default.py
+++ b/default.py
@@ -74,6 +74,7 @@ class MyMonitor( xbmc.Monitor ):
 class MyPlayer(xbmc.Player):
   duration = 0
   playingvideo = False
+  playlistlen = 0
   timer = None
   movie = False
 
@@ -86,6 +87,10 @@ class MyPlayer(xbmc.Player):
 
   def onPlayBackStarted(self):
     xbmc.log("Kodi Hue: DEBUG playback started called on player")
+    playlist = xbmc.PlayList(xbmc.PLAYLIST_VIDEO)
+    self.playlistlen = playlist.size()
+    self.playlistpos = playlist.getposition()
+
     if self.isPlayingVideo() and not self.playingvideo:
       self.playingvideo = True
       self.duration = self.getTotalTime()
@@ -122,8 +127,18 @@ class MyPlayer(xbmc.Player):
 
   def onPlayBackStopped(self):
     xbmc.log("Kodi Hue: DEBUG playback stopped called on player")
-    #logger.debuglog("onPlayBackStopped called.")
-    #if self.playingvideo: #don't check this, just fire the event no matter what.
+    self.playingvideo = False
+    self.playlistlen = 0
+    if self.movie and not self.timer is None:
+      self.timer.stop()
+    state_changed("stopped", self.duration)
+
+  def onPlayBackEnded(self):
+    xbmc.log("Kodi Hue: DEBUG playback ended called on player")
+    # If there are upcoming plays, ignore 
+    if self.playlistpos < self.playlistlen-1:
+      return
+      
     self.playingvideo = False
     if self.movie and not self.timer is None:
       self.timer.stop()


### PR DESCRIPTION
Hi,

When I use the ambilight plugin with other plugins such as Cinema Vision, the ambilight plugin stop working when multiple short videos are played.
CinemaVision adds multiple shorts before a movie (trailer, theater intro, dolby/atmos screens etc...) and the ambilight plugin in ambilight mode doesn't survive CinemaVision intro.

Fixes from koying solved the problem here.
