### PR TITLE
state_change: halt when screensaver addon is running

### DIFF
--- a/default.py
+++ b/default.py
@@ -729,6 +729,11 @@ def check_time(cur_time):
 def state_changed(state, duration):
     logger.debuglog("state changed to: %s" % state)
 
+    if (xbmc.getCondVisibility('Window.IsActive(screensaver-atv4.xml)') or
+        xbmc.getCondVisibility('Window.IsActive(screensaver-video-main.xml)')):
+        logger.debuglog("add-on disabled for screensavers")
+        return
+
     if duration < hue.settings.misc_disableshort_threshold and hue.settings.misc_disableshort:
         logger.debuglog("add-on disabled for short movies")
         return


### PR DESCRIPTION
Hopefully fixes issue#31 - state_changed should be the entity responsible for theater mode dimming.