### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ To have a higher chance of issue being solved, please attach a log file. To reco
 # Note for ARM users #
 ## Nvidia Shield / most Android boxes ##
 - _Ambilight mode_ doesn't properly work with 4k-HD codecs (>1080p) when "allow hardware acceleration - Mediacodec (Surface)" is enabled.
+## AppleTV 4K
+- _Ambilight mode_ doesn't properly work with 4k-HD codecs (>1080p) when "hasrware acceleration AVFundation" is enabled.
 ## Raspberry Pi's: ##
  - Save the add-on configuration by exiting Kodi before shutting down the Pi completely
  - _Ambilight mode_ might work on _Raspberry Pi's_ with most codecs and contents up to 1080p (feedback from thutterer on a RPI 3)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To have a higher chance of issue being solved, please attach a log file. To reco
 ## Nvidia Shield / most Android boxes ##
 - _Ambilight mode_ doesn't properly work with 4k-HD codecs (>1080p) when "allow hardware acceleration - Mediacodec (Surface)" is enabled.
 ## AppleTV 4K
-- _Ambilight mode_ doesn't properly work with 4k-HD codecs (>1080p) when "hasrware acceleration AVFundation" is enabled.
+- _Ambilight mode_ doesn't properly work with 4k-HD codecs (>1080p) when "hardware acceleration AVFundation" is enabled.
 ## Raspberry Pi's: ##
  - Save the add-on configuration by exiting Kodi before shutting down the Pi completely
  - _Ambilight mode_ might work on _Raspberry Pi's_ with most codecs and contents up to 1080p (feedback from thutterer on a RPI 3)


### PR DESCRIPTION
In the AppleTV 4K,  _Ambilight mode_ doesn't properly work with 4k-HD codecs (>1080p) when "hasrware acceleration AVFundation" is enabled.